### PR TITLE
Use updated Enumerable.List.slice/4

### DIFF
--- a/lib/ordered_map.ex
+++ b/lib/ordered_map.ex
@@ -521,7 +521,7 @@ defimpl Enumerable, for: OrderedMap do
 
   def slice(%{keys: _, map: _, size: _} = omap) do
     list = Enum.into(omap, [])
-    fun  = &Enumerable.List.slice(list, &1, &2)
+    fun  = &Enumerable.List.slice(list, &1, &2, omap.size)
 
     {:ok, omap.size, fun}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,10 +3,10 @@ defmodule OrderedMap.Mixfile do
 
   def project do
     [ app: :ordered_map,
-      version: "0.0.4",
+      version: "0.0.5",
       name: "OrderedMap",
       source_url: "https://github.com/jonnystorm/ordered-map-elixir",
-      elixir: "~> 1.3",
+      elixir: "~> 1.10",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),
@@ -33,6 +33,6 @@ defmodule OrderedMap.Mixfile do
   end
 
   defp deps do
-    [{:ex_doc, "~> 0.13", only: :dev}]
+    [{:ex_doc, "~> 0.21", only: :dev}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "0db1ee8d1547ab4877c5b5dffc6604ef9454e189928d5ba8967d4a58a801f161"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
 }


### PR DESCRIPTION
As of Elixir 1.10 the compiler warns the Enumerable.List.slice/3 is not defined. This uses `slice/4` instead and bumps the required Elixir version to 1.10.

Since Enumerable.List seems to be internal to the Elixir language, I'm not aware of a good mechanism to pass in a different version based on the language level. (I did try to use an `if` with `Module.defines?/2`, but it will always generate a compiler warning that one version of the function being referenced is not defined.)